### PR TITLE
bump: update pmd-legacy java docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,102 +1,38 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@0.1.0
-
-jobs:
-
-
-  checkout_and_version:
-    docker:
-      - image: codacy/git-version:1.0.8
-    working_directory: ~/workdir
-    steps:
-      - checkout
-      - run:
-          name: Set version
-          command: /bin/git-version > .version
-      - run:
-          name: Set Sbt version
-          command: echo "version in ThisBuild := \"$(cat .version)\"" > version.sbt
-      - run:
-          name: Current version
-          command: cat .version
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - workdir
-
-  build:
-    machine: true
-    working_directory: ~/workdir
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: 
-          name: Clone test project
-          working_directory: ~/
-          command: |
-            (git -C ~/codacy-plugins-test fetch --all && 
-              git -C ~/codacy-plugins-test reset --hard origin/master) || 
-                git clone git://github.com/codacy/codacy-plugins-test.git ~/codacy-plugins-test
-      - restore_cache:
-          key: dependencies-{{ checksum "build.sbt" }}
-      - run: 
-          name: Compile test project
-          working_directory: ~/codacy-plugins-test
-          command: sbt compile
-      - run: 
-          name: Publish tool docker locally
-          working_directory: ~/workdir
-          command: sbt 'set version in Docker := "latest"' "set name := \"$CIRCLE_PROJECT_REPONAME\"" docker:publishLocal
-      - save_cache:
-          key: dependencies-{{ checksum "build.sbt" }}
-          paths:
-            - "~/.ivy2"
-            - "~/.m2"
-            - "~/.sbt"
-            - "~/codacy-plugins-test/target"
-            - "~/codacy-plugins-test/project/target"
-            - "~/codacy-plugins-test/project/project"
-            - "~/workdir/target"
-            - "~/workdir/project/target"
-            - "~/workdir/project/project"
-      - run: 
-          name: Test json
-          working_directory: ~/codacy-plugins-test
-          command: sbt -Dcodacy.tests.ignore.descriptions=true "runMain codacy.plugins.DockerTest json $CIRCLE_PROJECT_REPONAME:latest"
-      - run:
-          name: Test patterns
-          working_directory: ~/codacy-plugins-test
-          command: sbt -Dcodacy.tests.noremove=true -Dcodacy.tests.threads=8 "runMain codacy.plugins.DockerTest pattern $CIRCLE_PROJECT_REPONAME:latest"
-      - deploy:
-          name: Push application Docker image
-          command: |
-            publish_docker() {
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker tag $CIRCLE_PROJECT_REPONAME codacy/$CIRCLE_PROJECT_REPONAME
-              docker tag $CIRCLE_PROJECT_REPONAME codacy/$CIRCLE_PROJECT_REPONAME:$(cat .version)
-              docker push codacy/$CIRCLE_PROJECT_REPONAME
-              docker push codacy/$CIRCLE_PROJECT_REPONAME:$(cat .version)
-            }
-
-            case "${CIRCLE_BRANCH}" in
-                master|pmd-legacy) publish_docker;;
-            esac
+  codacy: codacy/base@4.1.7
+  codacy_plugins_test: codacy/plugins-test@0.15.4
 
 workflows:
   version: 2
-  build-and-deploy:
+  compile_test_deploy:
     jobs:
-      - checkout_and_version
-      - build:
+      - codacy/checkout_and_version:
+          write_sbt_version: true
+      - codacy/sbt:
+          name: publish_docker_local
+          cmd: |
+            sbt 'set version in Docker := "latest"' docker:publishLocal
+            docker save --output ~/workdir/docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
+          persist_to_workspace: true
           requires:
-            - checkout_and_version
-      - codacy/tag_version:
-          name: tag_version
+            - codacy/checkout_and_version
+      - codacy_plugins_test/run:
+          name: plugins_test
+          run_multiple_tests: true
           requires:
-            - build
+            - publish_docker_local
+      - codacy/publish_docker:
+          context: CodacyDocker
+          requires:
+            - plugins_test
           filters:
             branches:
               only:
                 - master
+      - codacy/tag_version:
+          name: tag_version
+          context: CodacyAWS
+          requires:
+            - codacy/publish_docker

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /target/
 .idea
 .DS_Store
+*~
+.*.swp


### PR DESCRIPTION
This changes the base docker image to [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin), which is an official image with regular updates (and supersedes adoptjdk). It also fixes some vulnerabilities detected in the image we are currently using.