### PR TITLE
Feature: run with default codacy rules (IO-47)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@6.1.4
-  codacy_plugins_test: codacy/plugins-test@1.0.1
+  codacy: codacy/base@7.0.0
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ workflows:
           name: publish_docker_local
           cmd: |
             sbt "runMain com.codacy.pmd.DocGenerator"
-            sbt "scalafmt::test;
-                 test:scalafmt::test;
-                 sbt:scalafmt::test;
-                 set version in Docker := \"latest\";
-                 docker:publishLocal"
+            sbt "scalafmt / test;
+                 Test / scalafmt / test;
+                 Sbt / scalafmt / test;
+                 set Docker / version := \"latest\";
+                 Docker / publishLocal;"
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
           persist_to_workspace: true
           requires:

--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,15 @@ import com.typesafe.sbt.packager.docker.{Cmd, ExecCmd}
 import sjsonnew.BasicJsonProtocol._
 
 organization := "codacy"
-
 name := "codacy-pmd"
-
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.8"
 
 lazy val toolVersionKey = SettingKey[String]("version of the underlying tool")
-
 toolVersionKey := "6.36.0"
 
 libraryDependencies ++= {
   val toolVersion = toolVersionKey.value
+
   Seq(
     "com.typesafe.play" %% "play-json" % "2.7.4",
     "com.codacy" %% "codacy-engine-scala-seed" % "5.0.1",
@@ -32,7 +30,6 @@ libraryDependencies ++= {
 }
 
 enablePlugins(JavaAppPackaging)
-
 enablePlugins(DockerPlugin)
 
 val installAll =
@@ -40,8 +37,8 @@ val installAll =
     |rm -rf /tmp/* &&
     |rm -rf /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator(), " ")
 
-mappings in Universal ++= {
-  (resourceDirectory in Compile) map { (resourceDir: File) =>
+Universal / mappings ++= {
+  (Compile / resourceDirectory) map { (resourceDir: File) =>
     val src = resourceDir / "docs"
     val dest = "/docs"
 
@@ -62,16 +59,11 @@ Universal / javaOptions ++= Seq(
 val dockerUser = "docker"
 val dockerGroup = "docker"
 
-daemonUser in Docker := dockerUser
-
-daemonGroup in Docker := dockerGroup
-
+Docker / daemonUser := dockerUser
+Docker / daemonGroup := dockerGroup
 dockerBaseImage := "amazoncorretto:8-alpine3.14-jre"
-
-mainClass in Compile := Some("com.codacy.Engine")
-
+Compile / mainClass := Some("com.codacy.Engine")
 dockerEntrypoint := Seq("/sbin/tini", "-g", "--", s"/opt/docker/bin/${name.value}")
-
 dockerCommands := dockerCommands.value.flatMap {
   case cmd @ Cmd("WORKDIR", _) => List(Cmd("WORKDIR", "/src"), Cmd("RUN", installAll))
   case cmd @ (Cmd("ADD", _)) =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.1

--- a/src/main/scala/com/codacy/pmd/PMD.scala
+++ b/src/main/scala/com/codacy/pmd/PMD.scala
@@ -41,19 +41,19 @@ object PMD extends Tool {
           .mkString(",")
     }
 
-    // files could be empty when given explicitly by configuration a set of empty files to run.
+    // Files could be empty when given explicitly by configuration a set of empty files to run.
     // Confirm what happens in this case / what is the else that is missing from this flow (?)
     if (filesStr.nonEmpty) {
       pmdConfig.setInputPaths(filesStr)
     }
 
-    // side effectful code to make a pmdConfig with rules which at the start is null:
+    // Side effectful code to make a pmdConfig with rules which at the start is null:
     configuration match {
       case Some(config) =>
-        // if given patterns are empty this is empty, we generete a xml with some xml headers,
-        // but rules obviously are none. Don't know if it works or fails, should be tested....
-        // This should probably be protected as well since the code inside RulesetsFactoryUtils.getRuleSets checks is rules
-        // are != 0...
+        // If given patterns are empty, we generete a xml with some xml headers,
+        // but rules obviously are none. Don't know if or how it fails, needs testing here.
+        // Probably we want to protected here since the code inside
+        // RulesetsFactoryUtils.getRuleSets checks if rules are != 0...
         configFile(config) match {
           case Success(ruleset) =>
             pmdConfig.setRuleSets(ruleset.toString)
@@ -62,7 +62,7 @@ object PMD extends Tool {
         }
 
       case None =>
-        // if an explicit list of pattern was not provided, we try to look for the
+        // If an explicit list of pattern was not provided, we try to look for the
         // configuration file of the tool in the folder.
         // When we can't find a configuration file we generate a default
         // configuration that we defined as acceptable.
@@ -78,8 +78,8 @@ object PMD extends Tool {
           }
     }
 
-    // check we defined the rules to run, if not this is null, we should terminate since this is an error.
-    // Forcing a RETURN. This should only happen we we failed to generate a temporary configuration file.
+    // Check that we defined the rules to run, if not getRuleSets is null, we should terminate since this is an error.
+    // Forcing a RETURN. This should only happen when we failed to generate a temporary configuration file.
     if (pmdConfig.getRuleSets == null) {
       return Failure(new Exception("No rulesets were configured to initialize PMD tool"))
     }


### PR DESCRIPTION
Includes some quick bumps for scala and sbt.

The tools usually have a defined set of "recomended" rules that are run if no configuration is provided. That mode was missing.

The work to have the defaults was already done for the docs generation and so this was easily done.